### PR TITLE
set HOMEBREW_NO_INSTALL_FROM_API flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
+          HOMEBREW_NO_INSTALL_FROM_API: 1
           PULL_REQUEST: ${{ github.event.pull_request.number }}
         run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
 


### PR DESCRIPTION
Blocking https://github.com/wasmCloud/homebrew-wasmcloud/pull/28

I'm not sure that this will work, but I found some resources like https://github.com/Homebrew/brew/issues/14701 that indicate it might help