### PR TITLE
Added workflow dispatch for easy releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,8 +4,38 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      wash_version:
+        description: "Version of wash, without the `v`, to release to homebrew"
+        required: true
+        default: "0.18.0"
 jobs:
+  update-release:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare Formula
+        env:
+          WASMCLOUD_URL: https://github.com/wasmCloud/wash/archive/v{{ inputs.wash_version }}.tar.gz
+        run: |
+          template=$(cat ./template/wash.txt)
+          wasmcloud_url=$WASMCLOUD_URL
+          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1)
+          file_contents=$(echo "$template" | sed "s|WASMCLOUD_URL|$wasmcloud_url|")
+          file_contents=$(echo "$file_contents" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|")
+          echo "$file_contents" > Formula/wash.rb
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: bump wash to v${{ inputs.wash_version }}
+          title: wash v${{ inputs.wash_version }}
+          body: This is the release of wash v${{ inputs.wash_version }}. Once tests pass properly, add the `pr-pull` label to this PR to release.
+          branch: release/v${{ inputs.wash_version }}
+          signoff: true
   test-bot:
+    if: github.event_name != 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:

--- a/template/wash.txt
+++ b/template/wash.txt
@@ -1,0 +1,28 @@
+class Wash < Formula
+    desc "WAsmcloud SHell - a comprehensive command-line tool for wasmCloud development"
+    homepage "https://wasmcloud.com"
+    url "WASMCLOUD_URL"
+    sha256 "WASMCLOUD_SHA"
+    license "Apache-2.0"
+  
+    bottle do
+      root_url "https://github.com/wasmCloud/homebrew-wasmcloud/releases/download/wash-0.17.4"
+      sha256 cellar: :any_skip_relocation, big_sur:      "6779804593d697ac4b43c501c45ebe04ce3f42cac1e2f9f89f481d20ac5f9dac"
+      sha256 cellar: :any_skip_relocation, x86_64_linux: "5c202386e8f361a790f5416193b38888ab18453826f52db74d691c09afbe3e3f"
+    end
+  
+    depends_on "rust"
+  
+    on_linux do
+      depends_on "zlib"
+    end
+  
+    def install
+      system "cargo", "install", *std_cargo_args
+    end
+  
+    test do
+      system "#{bin}/wash", "-V"
+    end
+  end
+  


### PR DESCRIPTION
## Feature or Problem
This PR adds a simple workflow_dispatch trigger to tests that will enable maintainers to trigger a release giving a new wash version, and then the PR will be created automatically for you. This just cuts out a few middle steps around computing the hash and all that.
