### PR TITLE
Update Formula/wash.rb to install 0.23.0

### DIFF
--- a/Formula/wash.rb
+++ b/Formula/wash.rb
@@ -1,27 +1,44 @@
 class Wash < Formula
   desc "WAsmcloud SHell - a comprehensive command-line tool for wasmCloud development"
   homepage "https://wasmcloud.com"
-  url "https://github.com/wasmCloud/wash/archive/v0.21.1.tar.gz"
-  sha256 "e8ad9b215780c76447f124310e7aba6c10b42bd24a84c80b0de54fd0fffd9324"
+  version "0.23.0"
   license "Apache-2.0"
 
-  bottle do
-    root_url "https://github.com/wasmCloud/homebrew-wasmcloud/releases/download/wash-0.21.1"
-    sha256 cellar: :any_skip_relocation, monterey:     "427986add04b16c4376674c1c195ba96a8cb30774ad6c0c6bd35ee4e25ecf490"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "bf42e42efe71641ec4db79805303cc78fbea4c2473d5775bf90d1d6292f0bebe"
-  end
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-v0.23.0/wash-x86_64-apple-darwin"
+      sha256 "3adb9a837ade2658eb7604e15cb8cc9a6c797e39102fc342dd30083dfdd2a5c8"
 
-  depends_on "rust"
+      def install
+        bin.install "wash-x86_64-apple-darwin" => "wash"
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-v0.23.0/wash-aarch64-apple-darwin"
+      sha256 "8b6bb1caa51b9de3ddf338e482da0ecea3cb7327e042fe048dc8077df76e323e"
+
+      def install
+        bin.install "wash-aarch64-apple-darwin" => "wash"
+      end
+    end
+  end
 
   on_linux do
-    depends_on "zlib"
-  end
+    if Hardware::CPU.intel?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-v0.23.0/wash-x86_64-unknown-linux-musl"
+      sha256 "3ab9e4fe429b425a9fad08991ca7602a7a2c4cd507280196f79b1b398e54a6b7"
 
-  def install
-    system "cargo", "install", *std_cargo_args
-  end
+      def install
+        bin.install "wash-x86_64-unknown-linux-musl" => "wash"
+      end
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-v0.23.0/wash-aarch64-unknown-linux-musl"
+      sha256 "b21ba5f0697ca2ab53684b871e0809d1e3fa51241a1889c2f1b3e6bcd0fb2dd3"
 
-  test do
-    system "#{bin}/wash", "-V"
+      def install
+        bin.install "wash-aarch64-unknown-linux-musl" => "wash"
+      end
+    end
   end
 end

--- a/Formula/wash.rb
+++ b/Formula/wash.rb
@@ -41,4 +41,8 @@ class Wash < Formula
       end
     end
   end
+
+  test do
+    system "#{bin}/wash", "--version"
+  end
 end

--- a/Formula/wasmcloud.rb
+++ b/Formula/wasmcloud.rb
@@ -1,7 +1,7 @@
 class Wasmcloud < Formula
   desc "Secure, distributed, WebAssembly actor model runtime for everywhere"
   homepage "https://wasmcloud.dev"
-  url "https://github.com/wasmCloud/wasmCloud/archive/v0.18.2.tar.gz"
+  url "https://github.com/wasmCloud/wasmCloud/archive/refs/tags/v0.18.2.tar.gz"
   sha256 "6e393db103047909ee5295abbf95d460614b1a4dbca53fc9dda305451c7b1844"
   license "Apache-2.0"
 


### PR DESCRIPTION
## Feature or Problem

Since [wash-cli v0.23.0](https://github.com/wasmCloud/wasmCloud/releases/tag/wash-cli-v0.23.0) is available, let's update the wash formula to install that.

Note, this updates the formula to follow a more modern template, which avoids any building locally and simply downloads the OS/Architecture appropriate binaries.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing

I've locally validated that this works for darwin/arm64 and darwin/x86_64, but I haven't been able to find a good way to validate this against Linux brew for the Linux builds.

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
