### PR TITLE
refactor: update template to reflect monorepo and artifact releases

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,7 +5,7 @@ on:
       wash_version:
         description: "Version of wash, without the `v`, to release to homebrew"
         required: true
-        default: "0.18.0"
+        default: "0.23.0"
 jobs:
   update-release:
     runs-on: ubuntu-latest
@@ -13,12 +13,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Prepare Formula
         env:
-          WASMCLOUD_URL: https://github.com/wasmCloud/wash/archive/v${{ inputs.wash_version }}.tar.gz
+          WASH_VERSION: ${{ inputs.wash_version }}
         run: |
-          wasmcloud_url=$WASMCLOUD_URL
-          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1)
+          wash_version=$WASH_VERSION
 
-          cat ./template/wash.txt | sed "s|WASMCLOUD_URL|$wasmcloud_url|" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|" > Formula/wash.rb
+          cat ./template/wash.txt | sed "s|WASH_VERSION|$wash_version|" > Formula/wash.rb
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/template/wash.txt
+++ b/template/wash.txt
@@ -1,27 +1,54 @@
 class Wash < Formula
   desc "WAsmcloud SHell - a comprehensive command-line tool for wasmCloud development"
   homepage "https://wasmcloud.com"
-  url "WASMCLOUD_URL"
-  sha256 "WASMCLOUD_SHA"
+  version "WASH_VERSION"
   license "Apache-2.0"
 
   bottle do
-    root_url "https://github.com/wasmCloud/homebrew-wasmcloud/releases/download/wash-0.17.4"
-    sha256 cellar: :any_skip_relocation, big_sur:      "6779804593d697ac4b43c501c45ebe04ce3f42cac1e2f9f89f481d20ac5f9dac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "5c202386e8f361a790f5416193b38888ab18453826f52db74d691c09afbe3e3f"
+    root_url "https://github.com/wasmCloud/homebrew-wasmcloud/releases/download/wash-WASH_VERSION"
+    sha256 cellar: :any_skip_relocation, monterey:     "67c82144bb7fb673d7f4e0a6e686f811122bfd195fd6e6b4eb797a2c35bbc1d6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "a2914b468ed3dd845c5fce5677ee0c1a94bdf180a210424462c3342341f276fc"
   end
 
-  depends_on "rust"
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-WASH_VERSION/wash-x86_64-apple-darwin"
+      sha256 "3adb9a837ade2658eb7604e15cb8cc9a6c797e39102fc342dd30083dfdd2a5c8"
+
+      def install
+        bin.install "wash-x86_64-apple-darwin" => "wash"
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-WASH_VERSION/wash-aarch64-apple-darwin"
+      sha256 "8b6bb1caa51b9de3ddf338e482da0ecea3cb7327e042fe048dc8077df76e323e"
+
+      def install
+        bin.install "wash-aarch64-apple-darwin" => "wash"
+      end
+    end
+  end
 
   on_linux do
-    depends_on "zlib"
-  end
+    if Hardware::CPU.intel?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-WASH_VERSION/wash-x86_64-unknown-linux-musl"
+      sha256 "3ab9e4fe429b425a9fad08991ca7602a7a2c4cd507280196f79b1b398e54a6b7"
 
-  def install
-    system "cargo", "install", *std_cargo_args
+      def install
+        bin.install "wash-x86_64-unknown-linux-musl" => "wash"
+      end
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/wasmCloud/wasmCloud/releases/download/wash-cli-WASH_VERSION/wash-aarch64-unknown-linux-musl"
+      sha256 "b21ba5f0697ca2ab53684b871e0809d1e3fa51241a1889c2f1b3e6bcd0fb2dd3"
+
+      def install
+        bin.install "wash-aarch64-unknown-linux-musl" => "wash"
+      end
+    end
   end
 
   test do
-    system "#{bin}/wash", "-V"
+    system "#{bin}/wash", "--version"
   end
 end


### PR DESCRIPTION
**Leaving in draft because I'm not sure what a robust way of providing SHAs would be, short of downloading each artifact and computing the SHA manually. If that's the best approach, I can update this PR**

The new formula uses artifact releases from the monorepo, so I've updated the template to reflect that change