### PR TITLE
Change wash Formula update workflow to use Goreleaser

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,29 +1,82 @@
 name: brew formula update
+
 on:
   workflow_dispatch:
     inputs:
-      wash_version:
-        description: "Version of wash, without the `v`, to release to homebrew"
+      tag_prefix:
+        description: "Prefix for the release tag to pull from (i.e. wash-cli)"
+        default: "wash-cli"
+        required: false
+        type: string
+      tag_version:
+        description: "Tag to pull"
         required: true
-        default: "0.18.0"
+        type: string
+
 jobs:
   update-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Prepare Formula
-        env:
-          WASMCLOUD_URL: https://github.com/wasmCloud/wash/archive/v${{ inputs.wash_version }}.tar.gz
-        run: |
-          wasmcloud_url=$WASMCLOUD_URL
-          wasmcloud_sha=$(curl -sL $WASMCLOUD_URL | shasum -a 256 | cut -d ' ' -f 1)
+      - uses: actions/checkout@v4
 
-          cat ./template/wash.txt | sed "s|WASMCLOUD_URL|$wasmcloud_url|" | sed "s|WASMCLOUD_SHA|$wasmcloud_sha|" > Formula/wash.rb
+      # This is needed by Goreleaser to build the placeholder Go binary.
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+
+      - name: Normalize inputs for pipeline use
+        uses: actions/github-script@v7
+        id: normalize_inputs
+        with:
+          script: |
+            const input_tag = context.payload.inputs.tag_version
+            const input_prefix = context.payload.inputs.tag_prefix
+            const tag_no_v = input_tag.replaceAll('v', '')
+            const tag_with_v = 'v' + tag_no_v
+            const prefix = input_prefix.replace(/^-+/g, '').replace(/-+$/g, '')
+            const release_name = prefix + '-' + tag_with_v
+            core.setOutput('tag_no_v', tag_no_v)
+            core.setOutput('tag_with_v', tag_with_v)
+            core.setOutput('release_name', release_name)
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh -R wasmcloud/wasmcloud release download ${{ steps.normalize_inputs.outputs.release_name }} -D tmp/ -p '*apple-darwin*' -p '*unknown-linux*'
+
+      - name: Setup placeholder files for Goreleaser
+        shell: bash
+        run: |
+          mkdir tmp
+          cat <<EOF > tmp/main.go
+          package main
+          func main() {}
+          EOF
+
+      - name: Run Goreleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean --skip validate
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_NAME: ${{ steps.normalize_inputs.outputs.release_name }}
+          GORELEASER_CURRENT_TAG: ${{ steps.normalize_inputs.outputs.tag_no_v }}
+
+      - name: Copy the new Formula over
+        run: |
+          cp dist/homebrew/Formula/wash.rb Formula/wash.rb
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: bump wash to v${{ inputs.wash_version }}
-          title: wash v${{ inputs.wash_version }}
-          body: This is the release of wash v${{ inputs.wash_version }}. Once tests pass properly, add the `pr-pull` label to this PR to release.
-          branch: release/v${{ inputs.wash_version }}
+          commit-message: bump wash to ${{ steps.normalize_inputs.outputs.tag_with_v }}
+          title: wash ${{ steps.normalize_inputs.outputs.tag_with_v }}
+          body: This is the release of wash ${{ steps.normalize_inputs.outputs.tag_with_v }}. Once tests pass properly, add the `pr-pull` label to this PR to release.
+          branch: release/${{ steps.normalize_inputs.outputs.release_name }}
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          committer: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           signoff: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Goreleaser output directory
+dist/
+# Temporary files for update pipeline
+tmp/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,43 @@
+project_name: wash
+
+builds:
+  - main: tmp/main.go
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: wash
+    hooks:
+      post:
+        - ./.goreleaser_hook.sh {{ .Arch }} {{ .Os }} {{ .Path }}
+
+archives:
+  - format: binary
+
+brews:
+  - name: wash
+    goamd64: v1
+    url_template: https://github.com/wasmCloud/wasmCloud/releases/download/{{ indexOrDefault .Env "RELEASE_NAME" "" }}/{{ .Binary }}-{{ if eq .Arch "arm64" }}aarch64{{ else }}x86_64{{ end }}-{{ if eq .Os "darwin" }}apple-darwin{{ else }}unknown-linux-musl{{ end }}
+    license: "Apache-2.0"
+    folder: Formula
+    homepage: "https://wasmcloud.com/"
+    description: "WAsmcloud SHell - a comprehensive command-line tool for wasmCloud development"
+    skip_upload: true
+    test: |
+      system "#{bin}/wash", "-V"
+    install: |
+      bin.install "{{ .Binary }}-{{ if eq .Arch "arm64" }}aarch64{{ else }}x86_64{{ end }}-{{ if eq .Os "darwin" }}apple-darwin{{ else }}unknown-linux-musl{{ end }}" => "{{ .Binary }}"
+    repository:
+      owner: wasmCloud
+      name: homebrew-wasmcloud
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  skip: true
+
+release:
+  disable: true

--- a/.goreleaser_hook.sh
+++ b/.goreleaser_hook.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+go_arch=$1
+go_os=$2
+output_path=$3
+
+# Make Go -> Rust arch/os mapping
+case $go_arch in
+    amd64) rust_arch='x86_64' ;;
+    arm64) rust_arch='aarch64' ;;
+    *) echo "unknown arch: $go_arch" && exit 1 ;;
+esac
+case $go_os in
+    linux) rust_os='unknown-linux-musl' ;;
+    darwin) rust_os='apple-darwin' ;;
+    windows) rust_os='windows' ;;
+    *) echo "unknown os: $go_os" && exit 1 ;;
+esac
+
+# This deletes the output path before we attempt to place the Rust binaries there,
+# so that in the case we fail to download or `find` the Rust binaries below, the
+# pipeline will fail and we can investigate.
+rm "${output_path}"
+# Find the artifacts in tmp/ and move them over to dist/ where the Go binaries would be.
+find tmp -type f -name "*${rust_arch}-${rust_os}*" -exec mv {} "${output_path}" \;


### PR DESCRIPTION
## Feature or Problem

It would be nice to fully automate the process of updating the Homebrew formula for new `wash` releases, and one such tool to facilitate this is [Goreleaser](https://goreleaser.com/).

While Goreleaser doesn't have native Rust support, with a little bit of help from [prior art](https://www.qovery.com/blog/how-to-make-rust-multi-arch-release-easy), we can drive the process based on the [pre-built binaries from `wasmCloud/wasmCloud`](https://github.com/wasmCloud/wasmCloud/releases?q=wash-cli&expanded=true).

## Related Issues

This should pre-empt the need for #52, assuming we're open to trying out this approach instead.

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification

Worth noting, I've tested this pretty extensively in a private repository while iterating on it, but if you'd like to take this for a test drive locally, you should be able to do so with:

```shell
gh -R wasmcloud/wasmcloud release download wash-cli-v0.23.0 -D tmp/ -p '*apple-darwin*' -p '*unknown-linux*'

cat <<EOF > tmp/main.go
package main
func main() {}
EOF

RELEASE_NAME=wash-cli-v0.23.0 GORELEASER_CURRENT_TAG=0.23.0 goreleaser release --clean --skip validate

cat dist/homebrew/Formula/wash.rb
```

You will however need to download [`gh`](https://cli.github.com/) (`brew install gh`) and [`goreleaser`](https://goreleaser.com/install/) (`brew install goreleaser`).