### PR TITLE
ci: allow invoking via repository_dispatch

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,6 +1,8 @@
 name: brew formula update
 
 on:
+  repository_dispatch:
+    types: [brew-formula-update]
   workflow_dispatch:
     inputs:
       tag_prefix:
@@ -25,13 +27,26 @@ jobs:
         with:
           go-version: 1.21
 
+      - name: Set Variables
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "input_tag=${{ github.event.inputs.tag_version }}" >> $GITHUB_ENV
+          echo "input_prefix=${{ github.event.inputs.tag_prefix }}" >> $GITHUB_ENV
+      - name: Set Variables
+        if: github.event_name == 'repository_dispatch'
+        run: |
+          echo "input_tag=${{ github.event.client_payload.tag_version }}" >> $GITHUB_ENV
+          echo "input_prefix=${{ github.event.client_payload.tag_prefix }}" >> $GITHUB_ENV
+
       - name: Normalize inputs for pipeline use
         uses: actions/github-script@v7
         id: normalize_inputs
+        env:
+          input_tag: ${{ env.input_tag }}
+          input_prefix: ${{ env.input_prefix }}
         with:
           script: |
-            const input_tag = context.payload.inputs.tag_version
-            const input_prefix = context.payload.inputs.tag_prefix
+            const { input_tag, input_prefix } = process.env
             const tag_no_v = input_tag.replaceAll('v', '')
             const tag_with_v = 'v' + tag_no_v
             const prefix = input_prefix.replace(/^-+/g, '').replace(/-+$/g, '')


### PR DESCRIPTION
## Feature or Problem
This PR allows invoking the update action via repository_dispatch, which we can use to automatically trigger a homebrew update in this repo when a wash-cli release is created in wasmcloud/wasmcloud.

I tested this in my fork with a curl command (it failed because the action couldn't create the PR from my fork to here, which makes sense) https://github.com/brooksmtownsend/homebrew-wasmcloud/actions/runs/8940626563:
```
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <token> " \
  -H "X-GitHub-Api-Version: 2022-11-28" \
 https://api.github.com/repos/brooksmtownsend/homebrew-wasmcloud/dispatches \
-d '{"event_type":"brew-formula-update","client_payload":{"tag_prefix": "wash-cli", "tag_version": "v0.27.0"}}'
```

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
