### PR TITLE
feat: remove -cli suffix w/ new package

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,12 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       tag_prefix:
-        description: "Prefix for the release tag to pull from (i.e. wash-cli)"
-        default: "wash-cli"
+        description: 'Prefix for the release tag to pull from (i.e. wash)'
+        default: 'wash'
         required: false
         type: string
       tag_version:
-        description: "Tag to pull"
+        description: 'Tag to pull'
         required: true
         type: string
 


### PR DESCRIPTION
## Feature or Problem
This PR removes the `-cli` suffix for wash now that we are no longer using that for tags.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
