### PR TITLE
fix: switch Linux artifacts from musl to glibc

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_prefix:
-        description: 'Prefix for the release tag to pull from (i.e. wash)'
+        description: 'Optional prefix for the release tag (leave empty for unified tags like v2.0.3)'
         default: ''
         required: false
         type: string
@@ -52,7 +52,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh -R wasmcloud/wasmcloud release download "${{ steps.normalize_inputs.outputs.release_name }}" -D tmp/ -p '*apple-darwin*' -p '*unknown-linux*'
+          gh -R wasmcloud/wasmcloud release download "${{ steps.normalize_inputs.outputs.release_name }}" -D tmp/ -p '*apple-darwin*' -p '*unknown-linux-gnu'
 
       - name: Generate formula
         run: |

--- a/Formula/wash.rb.tmpl
+++ b/Formula/wash.rb.tmpl
@@ -28,21 +28,21 @@ class Wash < Formula
   on_linux do
     on_intel do
       if Hardware::CPU.is_64_bit?
-        url "${BASE_URL}/wash-x86_64-unknown-linux-musl"
-        sha256 "${SHA_X86_64_UNKNOWN_LINUX_MUSL}"
+        url "${BASE_URL}/wash-x86_64-unknown-linux-gnu"
+        sha256 "${SHA_X86_64_UNKNOWN_LINUX_GNU}"
 
         define_method(:install) do
-          bin.install "wash-x86_64-unknown-linux-musl" => "wash"
+          bin.install "wash-x86_64-unknown-linux-gnu" => "wash"
         end
       end
     end
     on_arm do
       if Hardware::CPU.is_64_bit?
-        url "${BASE_URL}/wash-aarch64-unknown-linux-musl"
-        sha256 "${SHA_AARCH64_UNKNOWN_LINUX_MUSL}"
+        url "${BASE_URL}/wash-aarch64-unknown-linux-gnu"
+        sha256 "${SHA_AARCH64_UNKNOWN_LINUX_GNU}"
 
         define_method(:install) do
-          bin.install "wash-aarch64-unknown-linux-musl" => "wash"
+          bin.install "wash-aarch64-unknown-linux-gnu" => "wash"
         end
       end
     end

--- a/generate-formula.sh
+++ b/generate-formula.sh
@@ -12,8 +12,8 @@ export BASE_URL="https://github.com/wasmCloud/wasmCloud/releases/download/${RELE
 TARGETS=(
   "aarch64-apple-darwin"
   "x86_64-apple-darwin"
-  "aarch64-unknown-linux-musl"
-  "x86_64-unknown-linux-musl"
+  "aarch64-unknown-linux-gnu"
+  "x86_64-unknown-linux-gnu"
 )
 
 for target in "${TARGETS[@]}"
@@ -30,13 +30,13 @@ export SHA_AARCH64_APPLE_DARWIN
 SHA_AARCH64_APPLE_DARWIN=$(sha256sum "tmp/wash-aarch64-apple-darwin" | cut -d' ' -f1)
 export SHA_X86_64_APPLE_DARWIN
 SHA_X86_64_APPLE_DARWIN=$(sha256sum "tmp/wash-x86_64-apple-darwin" | cut -d' ' -f1)
-export SHA_AARCH64_UNKNOWN_LINUX_MUSL
-SHA_AARCH64_UNKNOWN_LINUX_MUSL=$(sha256sum "tmp/wash-aarch64-unknown-linux-musl" | cut -d' ' -f1)
-export SHA_X86_64_UNKNOWN_LINUX_MUSL
-SHA_X86_64_UNKNOWN_LINUX_MUSL=$(sha256sum "tmp/wash-x86_64-unknown-linux-musl" | cut -d' ' -f1)
+export SHA_AARCH64_UNKNOWN_LINUX_GNU
+SHA_AARCH64_UNKNOWN_LINUX_GNU=$(sha256sum "tmp/wash-aarch64-unknown-linux-gnu" | cut -d' ' -f1)
+export SHA_X86_64_UNKNOWN_LINUX_GNU
+SHA_X86_64_UNKNOWN_LINUX_GNU=$(sha256sum "tmp/wash-x86_64-unknown-linux-gnu" | cut -d' ' -f1)
 
 # shellcheck disable=SC2016
-envsubst '$BASE_URL $SHA_AARCH64_APPLE_DARWIN $SHA_X86_64_APPLE_DARWIN $SHA_AARCH64_UNKNOWN_LINUX_MUSL $SHA_X86_64_UNKNOWN_LINUX_MUSL' \
+envsubst '$BASE_URL $SHA_AARCH64_APPLE_DARWIN $SHA_X86_64_APPLE_DARWIN $SHA_AARCH64_UNKNOWN_LINUX_GNU $SHA_X86_64_UNKNOWN_LINUX_GNU' \
   <Formula/wash.rb.tmpl >Formula/wash.rb
 
 echo "Generated Formula/wash.rb for wash ${RELEASE_TAG}"


### PR DESCRIPTION
Upstream wasmCloud/wasmCloud#5078 added glibc-linked Linux builds pinned
to glibc 2.17 (RHEL 7-era) via cargo zigbuild. Switch the tap to those
artifacts so wash can dlopen glibc-linked system libraries (GPU drivers,
etc.) on mainstream distros where the musl build couldn't.

Now this does not YET update the formula to point to the new artifacts,
but it does prepare the template, generator, and update.yml to make that
switch in the next release bump.
